### PR TITLE
Add `:hibernate` to callbacks of `TimeZoneInfo.Worker`

### DIFF
--- a/lib/time_zone_info/worker.ex
+++ b/lib/time_zone_info/worker.ex
@@ -51,23 +51,23 @@ defmodule TimeZoneInfo.Worker do
   @impl true
   def init(_opts) do
     state = do_update(:run)
-    {:ok, state}
+    {:ok, state, :hibernate}
   end
 
   @impl true
   def handle_info(:update, state) do
     state = do_update(:run, state)
-    {:noreply, state}
+    {:noreply, state, :hibernate}
   end
 
   @impl true
   def handle_call({:update, opt}, _from, state) do
     state = do_update(opt, state)
-    {:reply, reply(state), state}
+    {:reply, reply(state), state, :hibernate}
   end
 
   def handle_call(:state, _from, state) do
-    {:reply, reply(state), state}
+    {:reply, reply(state), state, :hibernate}
   end
 
   def handle_call(:next, _from, state) do
@@ -84,7 +84,7 @@ defmodule TimeZoneInfo.Worker do
           error
       end
 
-    {:reply, reply, state}
+    {:reply, reply, state, :hibernate}
   end
 
   defp do_update(step, state \\ :init) do


### PR DESCRIPTION
First of all, thanks for this lib, and keeping it up to date. I was looking for a time zone implementation that didn't automatically update, [following the wishes of the time zone database maintainers](https://github.com/lau/tzdata/issues/149) (although you probably already knew that).

I did notice though that in my work project the `TimeZoneInfo.Worker` process was sitting around 29MB of memory even after many hours of uptime. Although this really isn't that much, the next largest process is only 6MB, and for a service that sits around doing nothing 99.9% of the time, it seems a bit wasteful.

[Adding `:hibernate` to the callbacks allows for the GC to kick in](https://hexdocs.pm/elixir/GenServer.html#c:handle_call/3), and it brings the process down to a tiny 1.3kB, becoming the smallest process in my system. The only downside to `:hibernate` is that it causes extra churn in busy processes, so it seems perfect for this use case.

There is a small chance I'm completely wrong about this, but simple testing seems good :shrug: 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized internal process resource management for improved efficiency during idle periods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->