### PR TITLE
Fix OTP 29 IANA time conversion

### DIFF
--- a/lib/time_zone_info/iana_datetime.ex
+++ b/lib/time_zone_info/iana_datetime.ex
@@ -56,7 +56,12 @@ defmodule TimeZoneInfo.IanaDateTime do
 
   defp do_to_gregorian_seconds({date, time}) do
     date = update(date)
-    :calendar.datetime_to_gregorian_seconds({date, time})
+
+    :calendar.datetime_to_gregorian_seconds({date, {0, 0, 0}}) + time_to_seconds(time)
+  end
+
+  defp time_to_seconds({hour, minute, second}) do
+    hour * @seconds_per_hour + minute * @seconds_per_minute + second
   end
 
   defp update({year, month, day}) do

--- a/test/time_zone_info/iana_datetime_test.exs
+++ b/test/time_zone_info/iana_datetime_test.exs
@@ -21,6 +21,11 @@ defmodule TimeZoneInfo.IanaDateTimeTest do
                {2, 0, 0}
              ) == to_gregorian_seconds(~N[1973-11-04 02:00:00])
     end
+
+    test "returns seconds for datetimes at 24:00" do
+      assert IanaDateTime.to_gregorian_seconds(2009, 12, 31, {24, 0, 0}) ==
+               to_gregorian_seconds(~N[2010-01-01 00:00:00])
+    end
   end
 
   describe "to_gregorian_seconds/1" do
@@ -32,6 +37,11 @@ defmodule TimeZoneInfo.IanaDateTimeTest do
     test "with year, month, day, hour, minute and second" do
       assert IanaDateTime.to_gregorian_seconds({1999, 2, 3, 10, 11, 12}) ==
                to_gregorian_seconds(~N[1999-02-03 10:11:12])
+    end
+
+    test "with 24:00 at a month boundary" do
+      assert IanaDateTime.to_gregorian_seconds({2019, 1, 31, 24, 0, 0}) ==
+               to_gregorian_seconds(~N[2019-02-01 00:00:00])
     end
 
     test "with day as last day of week" do


### PR DESCRIPTION
OTP 29 validates calendar times more strictly and rejects IANA transition times such as 24:00 when passed to :calendar.datetime_to_gregorian_seconds/1.

Convert IANA datetimes by resolving the date at valid midnight and adding raw IANA time seconds. This preserves OTP 28 semantics while supporting end-of-day transition notation.

Add regression coverage for 24:00 day and month rollover.

Fixes #53

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved datetime calculations for edge cases at date boundaries, particularly for special time notations that occur at month and year transitions.

* **Tests**
  * Expanded test coverage to validate datetime handling at critical boundary conditions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hrzndhrn/time_zone_info/pull/54)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->